### PR TITLE
Raise when primary keys in Ecto are nils

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -519,7 +519,18 @@ if Code.ensure_loaded?(Ecto) do
             |> :erlang.term_to_iovec()
             |> :erlang.md5()
           else
-            Enum.map(primary_keys, &Map.get(record, &1))
+            primary_key_values = Enum.map(primary_keys, &Map.get(record, &1))
+
+            Enum.each(Enum.zip(primary_keys, primary_key_values), fn {key, value} ->
+              if is_nil(value) do
+                raise """
+                Key #{inspect(key)} is nil for record #{inspect(record)}.
+                Make sure to query all the fields that make up the primary key.
+                """
+              end
+            end)
+
+            primary_key_values
           end
 
         queryable = chase_down_queryable([assoc_field], schema)

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -477,6 +477,20 @@ defmodule Dataloader.EctoTest do
     end
   end
 
+  test "raises error when a primary key value is nil", %{loader: loader} do
+    %User{username: "Robert Lewandowski"} |> Repo.insert!()
+
+    user_with_nil_id =
+      from(u in User, select: [:username], where: u.username == "Robert Lewandowski")
+      |> Repo.one()
+
+    assert_raise RuntimeError, ~r/Key :id is nil for record/, fn ->
+      loader
+      |> Dataloader.load(Test, :posts, user_with_nil_id)
+      |> Dataloader.run()
+    end
+  end
+
   test "when dataloader times out it raises an error" do
     user =
       %User{username: "Ben Wilson"}


### PR DESCRIPTION
In some cases, when we have an Ecto payload, primary key can be set to nil. This can lead to situation where dataloader is associating the incorrect child object to a parent object. (See the issue here: https://github.com/absinthe-graphql/dataloader/issues/172).

This helps to avoid overlooking such situations by raising when nil was found in primary keys.